### PR TITLE
Update rust protobuf and alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.8
 MAINTAINER brennolncosta@gmail.com
 
 RUN apk add --update \
@@ -120,11 +120,11 @@ RUN apk --update add \
   libstdc++
 
 # Install  [rust-protobuf](https://github.com/stepancheg/rust-protobuf) plugin
-ENV RUST_PROTOBUF_VERSION 1.4.2
+ENV RUST_PROTOBUF_VERSION 2.0.2
 ENV RUSTPATH /rust
-RUN apk add cargo \
+RUN apk add cargo>1.26.0 \
   && mkdir $RUSTPATH \
-  && cargo install --root $RUSTPATH --vers $RUST_PROTOBUF_VERSION protobuf
+  && cargo install --all-features --root $RUSTPATH --vers $RUST_PROTOBUF_VERSION protobuf-codegen
 ENV PATH $RUSTPATH/bin:$PATH
 
 # Cleaning up

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV PROTOBUF_REVISION 3.5.0
 RUN curl -sLO https://github.com/google/protobuf/releases/download/v${PROTOBUF_REVISION}/protoc-${PROTOBUF_REVISION}-linux-x86_64.zip \
   && unzip protoc-${PROTOBUF_REVISION}-linux-x86_64.zip -d ./usr/local \
   && chmod +x /usr/local/bin/protoc \
+# Path of wellknown proto files
+  && chmod -R 755 /usr/local/include/ \
   && rm protoc-${PROTOBUF_REVISION}-linux-x86_64.zip
 
 ENV LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8


### PR DESCRIPTION
This basically covers updating the rust protobuf plugin, which has been renamed to the 2.0.2 version.

To have access to a cargo version that is not years old and can build the protobuf plugin version I also bumped the alpine version.

Furthermore I noticed that when using well known types in my protobuf files I had trouble including the path for protobuf wellknown types which end up in `/usr/include/google`. This is not Rust related but protoc which is unable to resolve the path.

Example file:

Example: x.proto
```
syntax = "proto3";

package abc;

import "google/protobuf/timestamp.proto";

message X {
    google.protobuf.Timestamp timestamp = 1;
}
```

That's the issue I saw before changing folder permissions:
```
docker run \           
  -v `pwd`:/my-protos \
  -w /my-protos \
  -u `id -u $USER`:`id -g $USER` \
  --rm -it proto protoc --cpp_out . x.proto --proto_path /usr/local/include/google --proto_path /my-protos
/usr/local/include/google: warning: directory does not exist.
x.proto: File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).
```

